### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/canuby/config.rb
+++ b/lib/canuby/config.rb
@@ -76,6 +76,7 @@ module Config
   # Migrate the config to a newer version. Not used until Canuby hits a more stable state.
   def self.migrate(from_version, to_version)
     return unless from_version != to_version
+
     logger.info("Migrating from #{from_version} to #{to_version}")
     case from_version
     when 0


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/SuperSandro2000/canuby/ruby_config_groups/859) to configure it on awesomecode.io